### PR TITLE
style(Alert): add z-index to ensure alert visibility

### DIFF
--- a/src/components/alerts/Alert.tsx
+++ b/src/components/alerts/Alert.tsx
@@ -10,7 +10,7 @@ type Props = {
 
 export const Alert = ({ isOpen, message, variant = 'warning' }: Props) => {
   const classes = classNames(
-    'fixed top-16 left-1/2 transform -translate-x-1/2 max-w-sm w-full shadow-lg rounded-lg pointer-events-auto ring-1 ring-black ring-opacity-5 overflow-hidden',
+    'fixed top-16 left-1/2 transform -translate-x-1/2 max-w-sm w-full shadow-lg rounded-lg pointer-events-auto ring-1 ring-black ring-opacity-5 overflow-hidden z-20',
     {
       'bg-rose-500 text-white': variant === 'warning',
       'bg-blue-500 text-white': variant === 'success',


### PR DESCRIPTION
The z-index was added to the Alert component to ensure it appears above other elements on the page, improving the user experience by making the alert more visible.
Alert should be even higher than Modals.

Before this change the alert were visible enough for the user when a modal was open:

| Before | After |
| --- | --- |
| ![image](https://github.com/user-attachments/assets/0ef89f51-ecce-4572-a64d-69d14abb515f) | ![image](https://github.com/user-attachments/assets/0a109f37-9921-4f60-a861-e5bfae158493) |